### PR TITLE
Potential fix for code scanning alert no. 5: Overly permissive regular expression range

### DIFF
--- a/practices/js/practice_8.js
+++ b/practices/js/practice_8.js
@@ -5,7 +5,7 @@ const submitButton = document.getElementById('submit-button');
 const emailResult = document.getElementById('email-result-box');
 
 submitButton.addEventListener('click', () => {
-    var regexEmail = /([A-z0-9._-]{1,})@(([A-z0-9]{2,}).[A-z0-9]{2,})/;
+    var regexEmail = /([A-Za-z0-9._-]{1,})@(([A-Za-z0-9]{2,}).[A-Za-z0-9]{2,})/;
     var email = emailBox.value.trim();
     
     if (regexEmail.test(email)) {


### PR DESCRIPTION
Potential fix for [https://github.com/anhvlt-2k6/WED201c_deploys/security/code-scanning/5](https://github.com/anhvlt-2k6/WED201c_deploys/security/code-scanning/5)

To fix the problem, we need to replace all instances of `[A-z]` in the regular expression with `[A-Za-z]`, which correctly matches only uppercase and lowercase English letters. This change should be made in the regex on line 8 of `practices/js/practice_8.js`. No additional imports or method definitions are required, as this is a simple regex correction. The rest of the code can remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
